### PR TITLE
DX-298-api-ref-tagging-and-releases-after-the-live-push

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -91,17 +91,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URLS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  Test:
-    name: Test Actions
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Main
-        uses: actions/checkout@v3
-        with:
-          repository: basiqio/basiq-github-actions
-          ref: main
-          token: ${{ env.PAT_GITHUB_TOKEN }}
-          path: ./.github/actions/basiq-github-actions
   TagAndRelease:
     name: Tag and Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed Test tags. 