### PR TITLE
DX-378 Remove Unsupported Job events from Webhooks

### DIFF
--- a/core.yml
+++ b/core.yml
@@ -804,8 +804,8 @@ paths:
                 Success:
                   value:
                     type: list
-                    size: 25
-                    count: 25
+                    size: 21
+                    count: 21
                     data:
                     - type: eventType
                       id: action.completed
@@ -857,26 +857,27 @@ paths:
                       description: time for a consent warning
                       links:
                         self: 'https://au-api.basiq.io/events/types/consent.warning'
-                    - type: eventType
-                      id: job.created
-                      description: when a job is created
-                      links:
-                        self: 'https://au-api.basiq.io/events/types/job.created'
-                    - type: eventType
-                      id: job.failed
-                      description: when a job is failed
-                      links:
-                        self: 'https://au-api.basiq.io/events/types/job.failed'
-                    - type: eventType
-                      id: job.in-progress
-                      description: when a job is in-progress
-                      links:
-                        self: 'https://au-api.basiq.io/events/types/job.in-progress'
-                    - type: eventType
-                      id: job.successful
-                      description: when a job is successful
-                      links:
-                        self: 'https://au-api.basiq.io/events/types/job.successful'
+                    # The Below events are not supported
+                    # - type: eventType
+                    #   id: job.created
+                    #   description: when a job is created
+                    #   links:
+                    #     self: 'https://au-api.basiq.io/events/types/job.created'
+                    # - type: eventType
+                    #   id: job.failed
+                    #   description: when a job is failed
+                    #   links:
+                    #     self: 'https://au-api.basiq.io/events/types/job.failed'
+                    # - type: eventType
+                    #   id: job.in-progress
+                    #   description: when a job is in-progress
+                    #   links:
+                    #     self: 'https://au-api.basiq.io/events/types/job.in-progress'
+                    # - type: eventType
+                    #   id: job.successful
+                    #   description: when a job is successful
+                    #   links:
+                    #     self: 'https://au-api.basiq.io/events/types/job.successful'
                     - type: eventType
                       id: payout.created
                       description: when a payout is created

--- a/webhooks.yml
+++ b/webhooks.yml
@@ -1,14 +1,14 @@
 openapi: 3.0.1
 info:
   description: Webhooks
-  version: "2.4.0"
+  version: "2.4.1"
   title: Webhooks
 servers:
   - description: Basiq Webhooks
     url: 'https://au-api.basiq.io/'
 tags:
   - name: Webhooks
-    description: Application (Core) APIs - The partners applications call these
+    description: BASIQ Webhooks
 paths:
   '/notifications/webhooks':
     post:


### PR DESCRIPTION
Below events are unsupported on webhooks

- job.created
- job.in-progress
- job.failed
- job.successful