### PR TITLE
DX-402 Add Validation for Webhook Subscription event

### DIFF
--- a/webhooks.yml
+++ b/webhooks.yml
@@ -67,6 +67,16 @@ paths:
                       code: 'invalid-content'
                       title: 'Invalid request content'
                       detail: 'Posted subscribedEvents contains unsupported event types.'
+                Event already subscribed to:
+                  value:
+                    type: 'list'
+                    correlationId: '9b27dbd7-d397-428a-9eff-5048d2bed5eb'
+                    data:
+                    - type: 'error'
+                      code: 'event-already-subscribed'
+                      title: 'Event already subscribed'
+                      detail: 'Posted subscribedEvents contains events that are already subscribed to for this application.'
+                
         '401':
           description: 'Unauthorized'
           content:
@@ -1118,26 +1128,35 @@ components:
       properties:
         type:
           type: string
+          description: Always "list".
         correlationId:
           type: string
+          description: Unique identifier for this particular occurrence of the problem.
         data:
           type: array
+          description: Error data.
           items:
             type: object
             properties:
               type:
                 type: string
+                description: Type of the response, always "error".
               code:
                 type: string
+                description: Application-specific error code, expressed as a string value.
               title:
                 type: string
+                description: Title of the error.
               detail:
                 type: string
+                description: Human-readable explanation specific to this occurrence of the problem.
               source:
                 type: object
+                description: An object containing references to the source of the error.
                 properties:
                   parameter:
                     type: string
+                    description: String indicating which URI query parameter caused the error.
     EventTypes:
       properties:
         type:

--- a/webhooks.yml
+++ b/webhooks.yml
@@ -334,6 +334,15 @@ paths:
                       code: 'invalid-content'
                       title: 'Invalid request content'
                       detail: 'Posted subscribedEvents contains unsupported event types.'
+                Event already subscribed to:
+                  value:
+                    type: 'list'
+                    correlationId: '9b27dbd7-d397-428a-9eff-5048d2bed5eb'
+                    data:
+                    - type: 'error'
+                      code: 'event-already-subscribed'
+                      title: 'Event already subscribed'
+                      detail: 'Posted subscribedEvents contains events that are already subscribed to for this application.'
         '401':
           description: 'Unauthorized'
           content:


### PR DESCRIPTION
### Event Subscription Restrictions

When creating or updating a webhook, partner applications must adhere to the following restrictions:

**Non-Duplicate Subscriptions**: Partners should not be allowed to subscribe to an event that has already been assigned to another webhook within the same application.

**Error Handling**: If a webhook creation or update request is attempted for an event that has already been subscribed to, the API will return an error response to notify the partner application.

