### PR TITLE
DX-605 Update Balance as Optional as per OB Conn type

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -2768,7 +2768,6 @@ components:
       - reference
       - account
       - amount
-      - balance
       - class
       - subClass
       - connection


### PR DESCRIPTION
Updating Balance as Optional from Required as we only return for Web connections and empty string for OB conn type. 