### PR TITLE
DX-779 Add new consent `revoked` field

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This is a CODEOWNERS file
 # It defines individuals or teams that are responsible for code in this repository.
 
-*       @adam-atawneh @kambasiq @basiq-brad
+*       @adam-atawneh @kambasiq @basiq-brad @basiq-esther

--- a/core.yml
+++ b/core.yml
@@ -299,7 +299,6 @@ paths:
                 $ref: '#/components/schemas/InternalServerError'
       security:
         - services_token: []
-      x-codegen-request-body-name: user
     delete:
       tags:
         - Users
@@ -398,7 +397,7 @@ paths:
                     created: '2022-11-01T05:07:00Z'
                     updated: '2022-11-01T05:07:00Z'
                     expiryDate: '2023-11-01T05:07:00Z'
-                    status: active
+                    status: revoked
                     purpose:
                       primary:
                         title: >-
@@ -471,6 +470,7 @@ paths:
                             description: >-
                               This allows access to transaction data for your
                               accounts. It includes all account transaction data.
+                    revoked: "2024-08-15T00:29:15Z"
                     links:
                       self: https://au-api.basiq.io/events/61acee1d-4508-4a96-ad48-42fa68e5bc19
                 expired:
@@ -3171,6 +3171,9 @@ components:
           $ref: '#/components/schemas/Purpose'
         data:
           $ref: '#/components/schemas/Data'
+        revoked: 
+          type: string
+          description: To indicate when a user consent was revoked.
         links:
           properties: 
             self:


### PR DESCRIPTION
🧰 Changes

- A new `revoked` field is added to the consent to indicate the revocation date.
- The revoked field is populated when user consent is deleted or when user is deleted.
- The format of revoked field is, now().UTC().Format(time.RFC3339))