### PR TITLE
DX-778 [+] Reminder in Reports for Purge and Refresh Connections when Enrich in Updated

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -665,9 +665,12 @@ paths:
       tags:
         - Connections
       summary: Purge connection data
-      description: >-
-        Use this to remove all user data for a specific institution.
-        This endpoint should be used only for active user connections.
+      description: |-
+        Use this endpoint to remove all user data related to a specific institution. Purging is only applicable for active user connections.
+  
+        When Enrich data is updated, the Enrich results under transactions won’t automatically reflect these updates. To ensure the latest Enrich results are available, partners should first purge and then refresh connections. Without this step, any new insight reports generated will not include the latest enriched data.
+  
+        > 📘 **Note:** Remember to purge and refresh connections to keep Enrich insights current.
       operationId: purgeConnectionData
       parameters:
         - name: userId

--- a/reports.yml
+++ b/reports.yml
@@ -34,6 +34,10 @@ paths:
         This API allows generating reports with various filters. The `filters` field in the report request enables you to specify parameters for customizing the report content.
 
         > 📘 Note: The report title cannot be longer than 50 characters.
+        
+        
+        > 📘 **Reminder:** When Enrich data is updated, the transactions' Enrich results won’t automatically reflect these updates. To ensure your report reflects the latest Enrich data, purge and refresh connections before generating a new report.
+
 
         ### Filters 
         


### PR DESCRIPTION
**🧰 Changes:**

- Updated the description for the `/users/{userId}/connections/{connectionId}/purge` endpoint to include a reminder for purging and refreshing connections to maintain updated Enrich data.

- Enhanced `/reports` endpoint description to remind partners to refresh Enrich data by purging connections prior to report generation.
