### PR TITLE
DX-869 fix: Missing Params in Enrich EP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This is a CODEOWNERS file
 # It defines individuals or teams that are responsible for code in this repository.
 
-*       @basiq-esther @basiq-jon @basiqio/devsecops @basiqio/developer-experience
+*       @basiq-esther @basiq-jon @basiqio/devsecops @basiqio/developer-experience @basiqio/platform-support

--- a/enrich.yml
+++ b/enrich.yml
@@ -47,6 +47,39 @@ paths:
         schema:
           type: string
         required: true
+      - name: mcc
+        in: query
+        description: >-
+          Merchant classification code as defined by Visa and Mastercard
+          
+          ```q=garfish%20MANLY%20NS&country=AU&institution=AU06703&**mcc=3299**```
+        schema:
+          type: string
+      - name: accountType
+        in: query
+        description: >- 
+          The Account type from which the transaction was derived.
+          
+          ```METRO%20PETROLEUM%20FR%20FORE&country=AU&accountType=transaction&institution=AU04301```
+          
+          **Valid values:**
+          
+          - `transaction`
+          - `credit-card`
+          - `savings`
+          - `mortgage`
+          - `loan`
+          - `foreign`
+        schema: 
+          type: string
+      - name: amount
+        in: query
+        description: >- 
+          The dollar/cent amount relevant to the transaction.
+          
+          ```q=garfish%20MANLY%20NS&country=AU&institution=AU06703&**amount=-12.95**```
+        schema: 
+          type: string
       responses:
         200:
           description: >-


### PR DESCRIPTION
- Addition of `mcc`, `accountType` and `amount` as Optional Parameters in Enrich EP. 